### PR TITLE
Add caption & citation fields to image block

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,12 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
-*
+
+[0.2.0] - 2019-10-21
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Added "caption" and "citation" fields to image XBlock
+
 
 [0.1.0] - 2019-08-28
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Added
-_____
 
 * First release on PyPI.

--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 
 def one():

--- a/labxchange_xblocks/image_block.py
+++ b/labxchange_xblocks/image_block.py
@@ -38,10 +38,26 @@ class ImageBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         scope=Scope.content,
     )
 
+    caption = String(
+        display_name=_('Image Caption'),
+        help=_('The legend/caption displayed under the image. Optional.'),
+        default='',
+        scope=Scope.content,
+    )
+
+    citation = String(
+        display_name=_('Image Citation'),
+        help=_('Citation/credit explaining where the image is from. Optional.'),
+        default='',
+        scope=Scope.content,
+    )
+
     editable_fields = (
         'display_name',
         'alt_text',
         'image_url',
+        'caption',
+        'citation',
     )
 
     student_view_template = 'templates/image_student_view.html'
@@ -54,5 +70,7 @@ class ImageBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         return {
             'display_name': self.display_name,
             'alt_text': self.alt_text,
-            'image_url': self.image_url,
+            'image_url': self.expand_static_url(self.image_url),
+            'caption': self.caption,
+            'citation': self.citation,
         }

--- a/labxchange_xblocks/public/css/image-xblock.css
+++ b/labxchange_xblocks/public/css/image-xblock.css
@@ -1,27 +1,24 @@
-.image-block-student-view {
-  max-height: 100vh;
-}
-
-.image-block-image {
+.image-block-student-view .image-block-image {
   display: block;
   margin: 0 auto;
   max-width: 100%;
-  max-height: 100%;
+  max-height: 100vh;
 }
 
-.image-block-student-view .caption {
+.image-block-student-view figcaption {
   text-align: center;
   max-width: 80%;
   margin: 1em auto;
 }
 
-.image-block-student-view .caption .citation {
+.image-block-student-view figcaption cite {
   color: #777;
 }
 
-.image-block-student-view .caption .caption + .citation::before {
+.image-block-student-view figcaption .caption + cite::before {
   content: '(';
 }
-.image-block-student-view .caption .caption + .citation::after {
+
+.image-block-student-view figcaption .caption + cite::after {
   content: ')';
 }

--- a/labxchange_xblocks/public/css/image-xblock.css
+++ b/labxchange_xblocks/public/css/image-xblock.css
@@ -8,3 +8,20 @@
   max-width: 100%;
   max-height: 100%;
 }
+
+.image-block-student-view .caption {
+  text-align: center;
+  max-width: 80%;
+  margin: 1em auto;
+}
+
+.image-block-student-view .caption .citation {
+  color: #777;
+}
+
+.image-block-student-view .caption .caption + .citation::before {
+  content: '(';
+}
+.image-block-student-view .caption .caption + .citation::after {
+  content: ')';
+}

--- a/labxchange_xblocks/templates/image_student_view.html
+++ b/labxchange_xblocks/templates/image_student_view.html
@@ -1,3 +1,9 @@
 <div class="image-block-student-view">
     <img class="image-block-image" src="{{ image_url }}" alt="{{ alt_text }}"/>
+    {% if caption or citation %}
+    <p class="caption">
+        {% if caption %}<span class="caption">{{ caption }}</span>{% endif %}
+        {% if citation %}<span class="citation">{{ citation }}</span>{% endif %}
+    </p>
+    {% endif %}
 </div>

--- a/labxchange_xblocks/templates/image_student_view.html
+++ b/labxchange_xblocks/templates/image_student_view.html
@@ -1,9 +1,9 @@
-<div class="image-block-student-view">
+<figure class="image-block-student-view">
     <img class="image-block-image" src="{{ image_url }}" alt="{{ alt_text }}"/>
     {% if caption or citation %}
-    <p class="caption">
+    <figcaption>
         {% if caption %}<span class="caption">{{ caption }}</span>{% endif %}
-        {% if citation %}<span class="citation">{{ citation }}</span>{% endif %}
-    </p>
+        {% if citation %}<cite>{{ citation }}</cite>{% endif %}
+    </figcaption>
     {% endif %}
-</div>
+</figure>

--- a/labxchange_xblocks/tests/image_block_test.py
+++ b/labxchange_xblocks/tests/image_block_test.py
@@ -27,9 +27,9 @@ class ImageBlockTestCase(BlockTestCaseBase):
             },
             # And this HTML:
             (
-                '<div class="image-block-student-view">\n'
+                '<figure class="image-block-student-view">\n'
                 '<img alt="" class="image-block-image" src=""/>\n'
-                '</div>'
+                '</figure>'
             )
         ), (
             # When providing this field data:
@@ -50,14 +50,14 @@ class ImageBlockTestCase(BlockTestCaseBase):
             },
             # And this HTML:
             (
-                '<div class="image-block-student-view">\n'
+                '<figure class="image-block-student-view">\n'
                 '<img alt="Map of the moon - چاند کا نقشہ" class="image-block-image"\n'
                 ' src="https://cdn.org/moon.jpeg"/>\n'
-                '<p class="caption">\n'
+                '<figcaption>\n'
                 '<span class="caption">Fig. 1: Map of the moon - چاند کا نقشہ</span>\n'
-                '<span class="citation">Courtesy NASA Lunar Reconnaissance Orbiter science team</span>\n'
-                '</p>\n'
-                '</div>'
+                '<cite>Courtesy NASA Lunar Reconnaissance Orbiter science team</cite>\n'
+                '</figcaption>\n'
+                '</figure>'
             )
         )
     )

--- a/labxchange_xblocks/tests/image_block_test.py
+++ b/labxchange_xblocks/tests/image_block_test.py
@@ -15,32 +15,48 @@ class ImageBlockTestCase(BlockTestCaseBase):
 
     data = (
         (
+            # When providing no field data (all default)
             {},
+            # Then we expect this student_view_data output:
             {
                 'display_name': 'Image',
                 'alt_text': '',
                 'image_url': '',
+                'caption': '',
+                'citation': '',
             },
+            # And this HTML:
             (
                 '<div class="image-block-student-view">\n'
                 '<img alt="" class="image-block-image" src=""/>\n'
                 '</div>'
             )
         ), (
+            # When providing this field data:
             {
-                'display_name': u'The moon - چاند',
-                'alt_text': u'Map of the moon - چاند کا نقشہ',
+                'display_name': 'The moon - چاند',
+                'alt_text': 'Map of the moon - چاند کا نقشہ',
                 'image_url': 'https://cdn.org/moon.jpeg',
+                'caption': 'Fig. 1: Map of the moon - چاند کا نقشہ',
+                'citation': 'Courtesy NASA Lunar Reconnaissance Orbiter science team',
             },
+            # Then we expect this student_view_data output:
             {
-                'display_name': u'The moon - چاند',
-                'alt_text': u'Map of the moon - چاند کا نقشہ',
+                'display_name': 'The moon - چاند',
+                'alt_text': 'Map of the moon - چاند کا نقشہ',
                 'image_url': 'https://cdn.org/moon.jpeg',
+                'caption': 'Fig. 1: Map of the moon - چاند کا نقشہ',
+                'citation': 'Courtesy NASA Lunar Reconnaissance Orbiter science team',
             },
+            # And this HTML:
             (
                 '<div class="image-block-student-view">\n'
                 '<img alt="Map of the moon - چاند کا نقشہ" class="image-block-image"\n'
                 ' src="https://cdn.org/moon.jpeg"/>\n'
+                '<p class="caption">\n'
+                '<span class="caption">Fig. 1: Map of the moon - چاند کا نقشہ</span>\n'
+                '<span class="citation">Courtesy NASA Lunar Reconnaissance Orbiter science team</span>\n'
+                '</p>\n'
                 '</div>'
             )
         )


### PR DESCRIPTION
Adds "caption" and "citation" fields. Both are displayed under the image.

Also ensures that `/static/blah.png` image URLs get rewritten in the `student_view_data`.

Test instructions: Create and/or edit one of these blocks in Studio. Note the new fields and how they appear:  
![Screen Shot 2019-10-18 at 3 46 47 PM](https://user-images.githubusercontent.com/945577/67123522-87723580-f1be-11e9-8adc-2a01c090a392.png)


Test the student view data: upload an image to "Files & Uploads", then set the "Image URL" of this block to the "Studio URL" of that image (/static/blah). Then go to http://localhost:18000/courses/course-v1:LX+XB+TEST/xblock/block-v1:LX+XB+TEST+type@lx_image+block@fc3d2444da814658afcc971d7020e737/handler/v1_student_view_data where the course ID and the block ID are changed as needed, and note that the result contains an expanded URL:

```
"image_url": "/assets/courseware/v1/c72ed18a748a2d4d2a4d491128a91799/asset-v1:LX+XB+TEST+type@asset+block/playing.jpeg"
```