### PR TITLE
Fix static URLs, allow anonymous access

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 
 def one():

--- a/labxchange_xblocks/document_block.py
+++ b/labxchange_xblocks/document_block.py
@@ -66,5 +66,5 @@ class DocumentBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
             'display_name': self.display_name,
             'document_type': self.document_type,
             'document_name': self.document_name,
-            'document_url': self.document_url,
+            'document_url': self.expand_static_url(self.document_url),
         }

--- a/labxchange_xblocks/utils.py
+++ b/labxchange_xblocks/utils.py
@@ -76,6 +76,8 @@ class StudentViewBlockMixin(XBlockMixin):
 
         return fragment
 
+    public_view = student_view
+
     @XBlock.handler
     def v1_student_view_data(self, request, suffix=None):  # pylint: disable=unused-argument
         """

--- a/labxchange_xblocks/utils.py
+++ b/labxchange_xblocks/utils.py
@@ -100,10 +100,10 @@ class StudentViewBlockMixin(XBlockMixin):
         Output: an absolute URL as a string, e.g. "https://cdn.none/course/234/image.png"
         """
         html_str = u'"{}"'.format(url)  # The static replacers look for quoted URLs like this
-        if hasattr(self.runtime, 'replace_static_urls_in_html'):
+        if hasattr(self.runtime, 'transform_static_paths_to_urls'):
             # This runtime supports the newest API for replacing static URLs,
             # where the static assets are specific to each XBlock:
-            url = self.runtime.replace_static_urls_in_html(self, html_str)[1:-1]
+            url = self.runtime.transform_static_paths_to_urls(self, html_str)[1:-1]
         elif hasattr(self.runtime, 'replace_urls'):
             # This is the LMS modulestore runtime, which has this API:
             url = self.runtime.replace_urls(html_str)[1:-1]


### PR DESCRIPTION
Adds a `public_view` so these XBlocks can be viewed by anonymous users.

An API in the new runtime to rewrite static URLs was renamed (to `transform_static_paths_to_urls`), so adding an asset with a URL like `/static/foo.png` was not working.

Also the document XBlock wasn't rewriting its URL at all in `student_view_data` (the image XBlock was, however).