### PR TITLE
Improve data that lx_assignment block provides about its children

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: python
 
 python:
-  - 2.7
   - 3.6
 
 env:
@@ -11,9 +10,6 @@ env:
   - TOXENV=django20
 
 matrix:
-  exclude:
-    - python: 2.7
-      env: TOXENV=django20
   include:
     - python: 3.6
       env: TOXENV=quality

--- a/labxchange_xblocks/case_study_block.py
+++ b/labxchange_xblocks/case_study_block.py
@@ -2,10 +2,6 @@
 """
 Case Study XBlock.
 """
-
-from __future__ import absolute_import, unicode_literals
-
-from six import text_type
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
 from xblock.fields import Scope, String
@@ -57,7 +53,7 @@ class CaseStudyBlock(
             child_block = self.runtime.get_block(child_usage_id)
             if child_block:
                 child_block_data = {
-                    'usage_id': text_type(child_usage_id),
+                    'usage_id': str(child_usage_id),
                     'block_type': child_block.scope_ids.block_type,
                     'display_name': child_block.display_name,
                 }

--- a/labxchange_xblocks/document_block.py
+++ b/labxchange_xblocks/document_block.py
@@ -2,9 +2,6 @@
 """
 Document XBlock.
 """
-
-from __future__ import absolute_import, unicode_literals
-
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblockutils.studio_editable import StudioEditableXBlockMixin

--- a/labxchange_xblocks/image_block.py
+++ b/labxchange_xblocks/image_block.py
@@ -2,9 +2,6 @@
 """
 Image XBlock.
 """
-
-from __future__ import absolute_import, unicode_literals
-
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblockutils.studio_editable import StudioEditableXBlockMixin

--- a/labxchange_xblocks/narrative_block.py
+++ b/labxchange_xblocks/narrative_block.py
@@ -2,9 +2,6 @@
 """
 Narrative XBlock.
 """
-
-from __future__ import absolute_import, unicode_literals
-
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblockutils.studio_editable import StudioEditableXBlockMixin

--- a/labxchange_xblocks/simulation_block.py
+++ b/labxchange_xblocks/simulation_block.py
@@ -2,9 +2,6 @@
 """
 Simulation XBlock.
 """
-
-from __future__ import absolute_import, unicode_literals
-
 from xblock.core import XBlock
 from xblock.fields import Scope, String
 from xblockutils.studio_editable import StudioEditableXBlockMixin

--- a/labxchange_xblocks/tests/assignment_block_test.py
+++ b/labxchange_xblocks/tests/assignment_block_test.py
@@ -58,11 +58,15 @@ class AssignmentBlockTestCase(XmlTest, BlockTestCaseBase):
                     'display_name': 'Assignment Document',
                     'usage_id': 'lx_document',
                     'graded': False,
+                    'max_attempts': None,
+                    'weight': 0,
                 }, {
                     'block_type': 'lx_image',
                     'display_name': 'Assignment Image',
                     'usage_id': 'lx_image',
                     'graded': False,
+                    'max_attempts': None,
+                    'weight': 0,
                 }
             ],
             u'display_name': u'Assignment 1'

--- a/labxchange_xblocks/utils.py
+++ b/labxchange_xblocks/utils.py
@@ -1,8 +1,6 @@
 """
 Helper code.
 """
-from __future__ import absolute_import, unicode_literals
-
 import json
 
 from web_fragments.fragment import Fragment

--- a/manage.py
+++ b/manage.py
@@ -2,9 +2,6 @@
 """
 Django administration utility.
 """
-
-from __future__ import absolute_import, unicode_literals
-
 import os
 import sys
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -24,8 +24,8 @@ pyparsing==2.4.2          # via packaging
 requests==2.22.0          # via codecov
 six==1.12.0               # via packaging, tox
 toml==0.10.0              # via tox
-tox-battery==0.5.1
-tox==3.14.0
+tox-battery==0.5.2
+tox==3.14.5
 urllib3==1.25.3           # via requests
 virtualenv==16.7.5        # via tox
 zipp==0.6.0               # via importlib-metadata

--- a/test_settings.py
+++ b/test_settings.py
@@ -4,9 +4,6 @@ These settings are here to use during tests, because django requires them.
 In a real-world use case, apps in this project are installed into other
 Django applications, so these settings will not be used.
 """
-
-from __future__ import absolute_import, unicode_literals
-
 from os.path import abspath, dirname, join
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-django{18,111},py36-django20
+envlist = {py36}-django111,py36-django20
 
 [doc8]
 max-line-length = 120
@@ -67,8 +67,7 @@ deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
     touch tests/__init__.py
-    pylint labxchange_xblocks tests test_utils
-    pylint --py3k labxchange_xblocks tests test_utils manage.py
+    pylint labxchange_xblocks tests test_utils manage.py
     rm tests/__init__.py
     pycodestyle labxchange_xblocks tests manage.py
     pydocstyle labxchange_xblocks tests manage.py


### PR DESCRIPTION
This updates the `student_view_data` of Assignment XBlocks so that for each child block:
1. `graded` is no longer based on the deprecated `graded` attribute, but rather `has_score` etc.
1. `max_attempts` is returned, if known
1. `weight` (maximum score that can be earned) is set, if known

This also updates the XBlock to properly handle `unit` children that themselves contain problems, e.g. if a Video or HTML is grouped together with a capa problem.