### PR TITLE
Implement the Audio XBlock

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,16 @@ Unreleased
 ~~~~~~~~~~
 
 
+[0.4.0] - 2020-04-19
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Drop Python 2 support
+* Improve data that lx_assignment block provides about its children
+* Remove Django dependencies
+* Fix Python 3 test issue
+* Implement the Audio XBlock
+
+
 [0.3.0] - 2019-10-31
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Overview
 4. Image XBlock
 5. Simulation XBlock (animated labs and exercises)
 6. Story in Science XBlock (stories from https://storiesinscience.org)
+7. Audio XBlock (renders embed codes from sites such as, but not limited to, SoundCloud or Sticher)
 
 License
 -------

--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 
 
 def one():

--- a/labxchange_xblocks/audio_block.py
+++ b/labxchange_xblocks/audio_block.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""
+Audio XBlock.
+"""
+from xblock.core import XBlock
+from xblock.fields import Scope, String
+from xblockutils.studio_editable import StudioEditableXBlockMixin
+
+from .utils import StudentViewBlockMixin, _
+
+
+class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
+    """
+    XBlock for audio embedding.
+    """
+
+    display_name = String(
+        display_name=_('Display Name'),
+        help=_('The name of the audio file.'),
+        default='Audio',
+        scope=Scope.content,
+    )
+
+    embed_code = String(
+        display_name=_('Embed code'),
+        default='',
+        help=_('The embed code of the audio file.'),
+        multiline_editor='html',
+        resettable_editor=False,
+        scope=Scope.content,
+    )
+
+    editable_fields = (
+        'display_name',
+        'embed_code',
+    )
+
+    student_view_template = 'templates/audio_student_view.html'
+    css_resource_url = 'public/css/audio-xblock.css'
+
+    def student_view_data(self, context=None):
+        """
+        Return content and settings for student view.
+        """
+        return {
+            'display_name': self.display_name,
+            'embed_code': self.embed_code,
+        }

--- a/labxchange_xblocks/public/css/audio-xblock.css
+++ b/labxchange_xblocks/public/css/audio-xblock.css
@@ -1,0 +1,3 @@
+.audio-block-student-view iframe {
+  border: none;
+}

--- a/labxchange_xblocks/templates/audio_student_view.html
+++ b/labxchange_xblocks/templates/audio_student_view.html
@@ -1,0 +1,3 @@
+<div class="audio-block-student-view">
+    {{ embed_code|safe }}
+</div>

--- a/labxchange_xblocks/tests/audio_block_test.py
+++ b/labxchange_xblocks/tests/audio_block_test.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import ddt
+
+from xblock.field_data import DictFieldData
+from labxchange_xblocks.audio_block import AudioBlock
+from utils import BlockTestCaseBase
+
+
+@ddt.ddt
+class AudioBlockTestCase(BlockTestCaseBase):
+
+    block_type = 'lx_audio'
+    block_class = AudioBlock
+
+    data = (
+        (
+            {},
+            {
+                'display_name': 'Audio',
+                'embed_code': '',
+            },
+            (
+                '<div class="audio-block-student-view">\n    \n</div>\n'
+            ),
+        ), (
+            {
+                'display_name': 'A very cool track',
+                'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
+            },
+            {
+                'display_name': 'A very cool track',
+                'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
+            },
+            (
+                '<div class="audio-block-student-view">\n    <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>\n</div>\n'  # noqa: E501
+            ),
+        )
+    )
+
+    @ddt.data(*data)
+    @ddt.unpack
+    def test_student_view_data(self, field_data, expected_data, _expected_html):
+        self._test_student_view_data(field_data, expected_data)
+
+    @ddt.data(*data)
+    @ddt.unpack
+    def test_student_view(self, field_data, _expected_data, expected_html):
+        block = self._construct_xblock_mock(self.block_class, self.keys, field_data=DictFieldData(field_data))
+
+        fragment = block.student_view(None)
+        self.assertEqual(fragment.content, expected_html)

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
     entry_points={
         'xblock.v1': [
             'lx_assignment = labxchange_xblocks.assignment_block:AssignmentBlock',
+            'lx_audio = labxchange_xblocks.audio_block:AudioBlock',
             'lx_case_study = labxchange_xblocks.case_study_block:CaseStudyBlock',
             'lx_document = labxchange_xblocks.document_block:DocumentBlock',
             'lx_image = labxchange_xblocks.image_block:ImageBlock',


### PR DESCRIPTION
This XBlock renders arbitrary HTML and/or Javascript at the discretion of the author, making it particularly useful for displaying embed codes from sites such as SoundCloud or Stitcher.