### PR TITLE
SE-2989 [LX-716] [SE-3026] [LX-793] add more customizable sections and attachments to case study

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ quality: ## check coding style with pycodestyle and pylint
 # uses.  We use no-cov and nomigrations because they _really_ speed up the test
 # run.
 test: clean
-	mkdir test_root
+	mkdir -p test_root
 	python -m pytest --ds=lms.envs.test --no-cov --nomigrations $(PROJECT_ROOT)labxchange_xblocks/tests/
 
 diff_cover: test ## find diff lines that need test coverage

--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.5.0'
+__version__ = '0.6.0'
 
 
 def one():

--- a/labxchange_xblocks/case_study_block.py
+++ b/labxchange_xblocks/case_study_block.py
@@ -4,7 +4,7 @@ Case Study XBlock.
 """
 from xblock.completable import XBlockCompletionMode
 from xblock.core import XBlock
-from xblock.fields import Scope, String
+from xblock.fields import List, Scope, String
 from xblockutils.studio_editable import (
     StudioContainerWithNestedXBlocksMixin,
     StudioEditableXBlockMixin,
@@ -26,40 +26,93 @@ class CaseStudyBlock(
     """
 
     display_name = String(
-        display_name=_('Display Name'),
-        help=_('The display name for this component.'),
-        default='Case Study',
+        display_name=_("Display Name"),
+        help=_("The display name for this component."),
+        default="Case Study",
         scope=Scope.content,
     )
 
+    # TODO: can we enforce stronger validation here, such as nested types, data shape?
+    sections = List(
+        help=_("""List of sections for this component.
+For example: [
+    {
+        "title": "Section 1",
+        "children": [
+            { "inlinehtml": "<span>hello</span>" },
+            { "usage_id": "lb:LabXchange:770d8e06:video:1-1" },
+        ],
+    }
+]
+"""),
+        scope=Scope.content,
+        display_name=_("Sections"),
+        enforce_type=True,
+    )
+
+    attachments = List(
+        help=_("List of ids of child xblocks to be shown as attachments, but not inline."),
+        scope=Scope.content,
+        display_name=_("Attachments"),
+        enforce_type=True,
+    )
+
     editable_fields = (
-        'display_name',
+        "display_name",
+        "sections",
+        "attachments",
     )
 
     completion_mode = XBlockCompletionMode.AGGREGATOR
-
     has_children = True
-    allowed_nested_blocks = xblock_specs_from_categories(('html', 'video', 'document'))
-
-    student_view_template = 'templates/case_study_student_view.html'
+    student_view_template = "templates/case_study_student_view.html"
 
     def student_view_data(self, context=None):
         """
         Return content and settings for student view.
         """
-        child_blocks_data = []
+        valid_child_block_ids = set()
+        child_blocks = []
 
         for child_usage_id in self.children:  # pylint: disable=no-member
             child_block = self.runtime.get_block(child_usage_id)
             if child_block:
+                valid_child_block_ids.add(str(child_usage_id))
                 child_block_data = {
-                    'usage_id': str(child_usage_id),
-                    'block_type': child_block.scope_ids.block_type,
-                    'display_name': child_block.display_name,
+                    "usage_id": str(child_usage_id),
+                    "block_type": child_block.scope_ids.block_type,
+                    "display_name": child_block.display_name,
                 }
-                child_blocks_data.append(child_block_data)
+                child_blocks.append(child_block_data)
+
+        sections = []
+        for section in self.sections:
+            children = []
+            for child in section.get("children"):
+                # Here we only add valid entries to the sections returned.
+                # This ensures that clients always get type-safe response.
+                if "inlinehtml" in child and isinstance(child["inlinehtml"], str):
+                    children.append({
+                        "inlinehtml": child["inlinehtml"]
+                    })
+                elif child.get("usage_id") in valid_child_block_ids:
+                    children.append({
+                        "usage_id": child["usage_id"],
+                    })
+
+            sections.append({
+                "title": section.get("title", ""),
+                "children": children,
+            })
+
+        attachments = []
+        for xblock_id in self.attachments:
+            if isinstance(xblock_id, str) and xblock_id in valid_child_block_ids:
+                attachments.append(xblock_id)
 
         return {
-            'display_name': self.display_name,
-            'child_blocks': child_blocks_data,
+            "display_name": self.display_name,
+            "sections": sections,
+            "child_blocks": child_blocks,
+            "attachments": attachments,
         }

--- a/labxchange_xblocks/templates/case_study_student_view.html
+++ b/labxchange_xblocks/templates/case_study_student_view.html
@@ -1,12 +1,20 @@
 <div class="case-study-block-student-view">
-    {% for child_block in child_blocks %}
-    <div class="case-study-block-child-student-view">
-        <div class="case-study-block-child-display-name">
-            {{ child_block.display_name }}
-        </div>
-        <div class="case-study-block-child-content">
-            {{ child_block.content|safe }}
-        </div>
-    </div>
+    {% for section in sections %}
+        <section class="case-study-block-section">
+            <h2 class="case-study-block-section-title">
+                {{ section.title }}
+            </h2>
+            {% for child in section.children %}
+                {% if child.inlinehtml %}
+                    <div class="case-study-block-child case-study-block-inlinetext-content">
+                        {{ child.inlinehtml|safe }}
+                    </div>
+                {% else %}
+                    <div class="case-study-block-child case-study-block-child-content">
+                        {{ child_blocks|get_xblock_content:child.usage_id|safe }}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </section>
     {% endfor %}
 </div>

--- a/labxchange_xblocks/tests/case_study_block_test.py
+++ b/labxchange_xblocks/tests/case_study_block_test.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import ddt
+
 from xblock.completable import XBlockCompletionMode
 from xblock.field_data import DictFieldData
 from xblock.fields import ScopeIds
@@ -12,54 +14,297 @@ from labxchange_xblocks.image_block import ImageBlock
 from utils import BlockTestCaseBase
 
 
+@ddt.ddt
 class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
 
-    block_type = 'lx_case_study'
+    block_type = "lx_case_study"
     block_class = CaseStudyBlock
 
     def test_is_aggregator(self):
-        self.assertEqual(XBlockCompletionMode.get_mode(CaseStudyBlock), XBlockCompletionMode.AGGREGATOR)
+        self.assertEqual(
+            XBlockCompletionMode.get_mode(CaseStudyBlock),
+            XBlockCompletionMode.AGGREGATOR,
+        )
 
-    def test_student_view_data(self):
+    def test_student_view_data_with_defaults(self):
 
-        field_data = {
-            'display_name': 'Case Study 1'
-        }
-        block = self._construct_xblock_mock(self.block_class, self.keys, field_data=DictFieldData(field_data))
+        field_data = {"display_name": "Case Study 1"}
+        block = self._construct_xblock_mock(
+            self.block_class, self.keys, field_data=DictFieldData(field_data)
+        )
 
-        document_block_keys = ScopeIds('a_user', 'lx_document', 'def_id_document', 'usage_id_document')
-        document_block = DocumentBlock(self.runtime_mock, scope_ids=document_block_keys, field_data=DictFieldData({
-            'display_name': 'CS Document',
-        }))
+        document_block_keys = ScopeIds(
+            "a_user", "lx_document", "def_id_document", "usage_id_document"
+        )
+        document_block = DocumentBlock(
+            self.runtime_mock,
+            scope_ids=document_block_keys,
+            field_data=DictFieldData({"display_name": "CS Document",}),
+        )
         block.children.append(document_block.scope_ids.block_type)
 
-        image_block_keys = ScopeIds('a_user', 'lx_image', 'def_id_image', 'usage_id_image')
-        image_block = self._construct_xblock_mock(ImageBlock, image_block_keys, field_data=DictFieldData({
-            'display_name': 'CS Image',
-        }))
+        image_block_keys = ScopeIds(
+            "a_user", "lx_image", "def_id_image", "usage_id_image"
+        )
+        image_block = self._construct_xblock_mock(
+            ImageBlock,
+            image_block_keys,
+            field_data=DictFieldData({"display_name": "CS Image",}),
+        )
         block.children.append(image_block.scope_ids.block_type)
 
         def get_block(usage_id):
-            if usage_id == 'lx_document':
+            if usage_id == "lx_document":
                 return document_block
-            if usage_id == 'lx_image':
+            if usage_id == "lx_image":
                 return image_block
 
         self.runtime_mock.get_block.side_effect = get_block
 
-        data = block.student_view_data(None)
+        data = block.student_view_data(context=None)
 
-        self.assertDictEqual(data, {
-            u'child_blocks': [
+        self.assertDictEqual(
+            data,
+            {
+                "child_blocks": [
+                    {
+                        "block_type": "lx_document",
+                        "display_name": "CS Document",
+                        "usage_id": "lx_document",
+                    },
+                    {
+                        "block_type": "lx_image",
+                        "display_name": "CS Image",
+                        "usage_id": "lx_image",
+                    },
+                ],
+                "display_name": "Case Study 1",
+                "sections": [],
+                "attachments": [],
+            },
+        )
+
+    @ddt.data(
+        (
+            [
                 {
-                    'block_type': 'lx_document',
-                    'display_name': 'CS Document',
-                    'usage_id': 'lx_document',
-                }, {
-                    'block_type': 'lx_image',
-                    'display_name': 'CS Image',
-                    'usage_id': 'lx_image',
-                }
+                    "title": "Section One",
+                    "children": [
+                        {"inlinehtml": "<span>hello</span>"},
+                        {"usage_id": "lx_image"},
+                        {
+                            "inlinehtml": ["ignore", "this"]
+                        },  # invalid type here will be dropped from output
+                        {"usage_id": "lx_image"},  # dups are ok here
+                    ],
+                },
+                {
+                    "title": "Section Two",
+                    "children": [
+                        {"inlinehtml": ""},
+                        {
+                            "usage_id": "NOTFOUNDINVALID"
+                        },  # invalid usage_ids should be silently ignored
+                    ],
+                },
             ],
-            u'display_name': u'Case Study 1'
-        })
+            [],
+            [
+                {
+                    "title": "Section One",
+                    "children": [
+                        {"inlinehtml": "<span>hello</span>"},
+                        {"usage_id": "lx_image"},
+                        {"usage_id": "lx_image"},  # dups are ok here
+                    ],
+                },
+                {"title": "Section Two", "children": [{"inlinehtml": ""},],},
+            ],
+            [],
+        ),
+        (
+            [
+                {
+                    "title": "Section One",
+                    "children": [
+                        {"inlinehtml": "<span>hello</span>"},
+                        {"usage_id": "lx_image"},
+                    ],
+                },
+                {
+                    "title": "Section Two",
+                    "children": [{"inlinehtml": "<p>One</p><p>Two</p>"},],
+                },
+            ],
+            [],
+            [
+                {
+                    "title": "Section One",
+                    "children": [
+                        {"inlinehtml": "<span>hello</span>"},
+                        {"usage_id": "lx_image"},
+                    ],
+                },
+                {
+                    "title": "Section Two",
+                    "children": [{"inlinehtml": "<p>One</p><p>Two</p>"},],
+                },
+            ],
+            [],
+        ),
+        ([], ["lx_image"], [], ["lx_image"],),
+        ([], ["lx_document", "lx_image"], [], ["lx_document", "lx_image"],),
+        # invalid/notfound attachments are dropped
+        (
+            [],
+            ["lx_document", "does_not_exist", "lx_image"],
+            [],
+            ["lx_document", "lx_image"],
+        ),
+        (
+            [],
+            ["lx_document", {"key": "invalid type"}, "lx_image"],
+            [],
+            ["lx_document", "lx_image"],
+        ),
+        (
+            [],
+            # duplicates are ok in attachments
+            ["lx_document", "lx_document", "lx_image"],
+            [],
+            ["lx_document", "lx_document", "lx_image"],
+        ),
+    )
+    @ddt.unpack
+    def test_student_view_data(
+        self, sections, attachments, expected_sections, expected_attachments
+    ):
+
+        field_data = {"display_name": "Case Study 3"}
+        block = self._construct_xblock_mock(
+            self.block_class, self.keys, field_data=DictFieldData(field_data)
+        )
+
+        document_block_keys = ScopeIds(
+            "a_user", "lx_document", "def_id_document", "usage_id_document"
+        )
+        document_block = DocumentBlock(
+            self.runtime_mock,
+            scope_ids=document_block_keys,
+            field_data=DictFieldData({"display_name": "CS Document",}),
+        )
+        block.children.append(document_block.scope_ids.block_type)
+
+        image_block_keys = ScopeIds(
+            "a_user", "lx_image", "def_id_image", "usage_id_image"
+        )
+        image_block = self._construct_xblock_mock(
+            ImageBlock,
+            image_block_keys,
+            field_data=DictFieldData({"display_name": "CS Image",}),
+        )
+        block.children.append(image_block.scope_ids.block_type)
+
+        block.sections = sections
+        block.attachments = attachments
+
+        def get_block(usage_id):
+            if usage_id == "lx_document":
+                return document_block
+            if usage_id == "lx_image":
+                return image_block
+
+        self.runtime_mock.get_block.side_effect = get_block
+
+        data = block.student_view_data(context=None)
+
+        self.assertDictEqual(
+            data,
+            {
+                "child_blocks": [
+                    {
+                        "block_type": "lx_document",
+                        "display_name": "CS Document",
+                        "usage_id": "lx_document",
+                    },
+                    {
+                        "block_type": "lx_image",
+                        "display_name": "CS Image",
+                        "usage_id": "lx_image",
+                    },
+                ],
+                "display_name": "Case Study 3",
+                "sections": expected_sections,
+                "attachments": expected_attachments,
+            },
+        )
+
+    def test_student_view_data_invalid_attachment(self):
+
+        field_data = {"display_name": "Case Study 4"}
+        block = self._construct_xblock_mock(
+            self.block_class, self.keys, field_data=DictFieldData(field_data)
+        )
+
+        document_block_keys = ScopeIds(
+            "a_user", "lx_document", "def_id_document", "usage_id_document"
+        )
+        document_block = DocumentBlock(
+            self.runtime_mock,
+            scope_ids=document_block_keys,
+            field_data=DictFieldData({"display_name": "CS Document",}),
+        )
+        block.children.append(document_block.scope_ids.block_type)
+
+        image_block_keys = ScopeIds(
+            "a_user", "lx_image", "def_id_image", "usage_id_image"
+        )
+        image_block = self._construct_xblock_mock(
+            ImageBlock,
+            image_block_keys,
+            field_data=DictFieldData({"display_name": "CS Image",}),
+        )
+        block.children.append(image_block.scope_ids.block_type)
+
+        with self.assertRaises(TypeError):
+            block.sections = {"key": "invalid"}
+        with self.assertRaises(TypeError):
+            block.sections = "foo"
+        block.sections = []
+
+        with self.assertRaises(TypeError):
+            block.attachments = {"key": "invalid"}
+        with self.assertRaises(TypeError):
+            block.attachments = "foo"
+        block.attachments = ["lx_image"]
+
+        def get_block(usage_id):
+            if usage_id == "lx_document":
+                return document_block
+            if usage_id == "lx_image":
+                return image_block
+
+        self.runtime_mock.get_block.side_effect = get_block
+
+        data = block.student_view_data(context=None)
+
+        self.assertDictEqual(
+            data,
+            {
+                "child_blocks": [
+                    {
+                        "block_type": "lx_document",
+                        "display_name": "CS Document",
+                        "usage_id": "lx_document",
+                    },
+                    {
+                        "block_type": "lx_image",
+                        "display_name": "CS Image",
+                        "usage_id": "lx_image",
+                    },
+                ],
+                "display_name": "Case Study 4",
+                "sections": [],
+                "attachments": ["lx_image"],
+            },
+        )

--- a/labxchange_xblocks/utils.py
+++ b/labxchange_xblocks/utils.py
@@ -3,6 +3,7 @@ Helper code.
 """
 import json
 
+from django.template.defaulttags import register
 from web_fragments.fragment import Fragment
 from webob import Response
 from xblock.core import XBlock, XBlockMixin
@@ -10,6 +11,17 @@ from xblockutils.resources import ResourceLoader
 from xblockutils.studio_editable import NestedXBlockSpec
 
 loader = ResourceLoader(__name__)
+
+
+@register.filter
+def get_xblock_content(child_blocks, usage_id):
+    """
+    Helper function to get the content of an xblock from the standard `child_blocks` list,
+    given an xblock `usage_id`.
+    """
+    for block in child_blocks:
+        if block.get("usage_id") == usage_id:
+            return block.get("content")
 
 
 def _(text):
@@ -75,6 +87,7 @@ class StudentViewBlockMixin(XBlockMixin):
                     child_block_content = child_block_fragment.content
                     fragment.add_fragment_resources(child_block_fragment)
                     child_blocks_data.append({
+                        'usage_id': str(child_usage_id),
                         'content': child_block_content,
                         'display_name': child_block.display_name,
                     })


### PR DESCRIPTION
This is a breaking change to how case studies are structured to support customizable sections, multiple children per section, and inline html text content.


**Test instructions**:

- deploy this branch along with https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/934
- follow test instructions with the labxchange PR

**Reviewers**:

- [x] @s0b0lev 
- [x] @bradenmacdonald or @symbolist may wish to sign off on this too