### PR TITLE
[SE-3111] Retrieve handler url from backend instead of frontend for audio xblock

### DIFF
--- a/labxchange_xblocks/audio_block.py
+++ b/labxchange_xblocks/audio_block.py
@@ -89,7 +89,10 @@ class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         current_language = None
         if languages:
             current_language = list(languages)[0]
-        return {'current_language': current_language}
+        return {
+            'current_language': current_language,
+            'sequences_url': self.runtime.handler_url(self, 'sequences', '', '').rstrip('/?'),
+        }
 
     @property
     def assets(self):

--- a/labxchange_xblocks/public/js/audio-xblock.js
+++ b/labxchange_xblocks/public/js/audio-xblock.js
@@ -8,7 +8,7 @@ function LXAudioXBlock(runtime, element, init_args) {
         this.toggleElement = this.element.find('.audio-block-transcript-toggle');
         this.currentLang = user_state.current_lang || '';
         this.folded = false;
-        this.getSequencesUrl = runtime.handlerUrl(element, 'sequences');
+        this.getSequencesUrl = user_state.sequences_url;
         this.init();
     }
 


### PR DESCRIPTION
This pull request is about updating the audio xblock to use labxchange handler URL instead of directly using the edx since it is not possible because of security (CORS) issues.

Current problem:

<img width="921" alt="Screen Shot 2020-09-23 at 1 18 26 PM" src="https://user-images.githubusercontent.com/293337/93966927-e9f58d80-fda0-11ea-9774-8b1de7ec5045.png">

The new URL that should be used:

<img width="724" alt="Screen Shot 2020-09-23 at 1 18 50 PM" src="https://user-images.githubusercontent.com/293337/93966952-fd085d80-fda0-11ea-877b-a5d73a532da7.png">

**Jira tickets**

- [SE-3111](https://tasks.opencraft.com/browse/SE-3111)

**Testing instructions**

- Update your devstack to use this branch (`toxinu/audio-block-follow-up`)
- Create an audio asset in labxchange
- Add a transcript on it
- Check that the url called to retrieve the transcripts is labxchange api (which will request edx api) so that we don't get any CORS error (only visible on stage and production but not locally, that's why I didn't spot it before)

**Reviewer**

- @s0b0lev 