### PR TITLE
[SE-3111] Use GET instead of POST to retrieve audio sequences

### DIFF
--- a/labxchange_xblocks/audio_block.py
+++ b/labxchange_xblocks/audio_block.py
@@ -141,7 +141,7 @@ class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         return response.content
 
     @XBlock.handler
-    def sequences(self, request, suffix=''):
+    def sequences(self, request, dispatch):
         """ Returns sequences based on lang parameter """
         lang = request.GET.get('lang', None)
         if not lang:

--- a/labxchange_xblocks/audio_block.py
+++ b/labxchange_xblocks/audio_block.py
@@ -2,6 +2,8 @@
 """
 Audio XBlock.
 """
+import json
+
 import six
 import requests
 from webob import Response
@@ -91,7 +93,6 @@ class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
             current_language = list(languages)[0]
         return {
             'current_language': current_language,
-            'sequences_url': self.runtime.handler_url(self, 'sequences', '', '').rstrip('/?'),
         }
 
     @property
@@ -139,17 +140,21 @@ class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         response = requests.get(url)
         return response.content
 
-    @XBlock.json_handler
-    def sequences(self, data, suffix=''):
+    @XBlock.handler
+    def sequences(self, request, suffix=''):
         """ Returns sequences based on lang parameter """
-        lang = data.get('lang')
+        lang = request.GET.get('lang', None)
         if not lang:
             lang = self.user_state.get('current_language')
 
         lang = lang.rstrip('/')
         asset = self.get_transcript_asset(lang)
         content = self.get_transcript_content(asset.url)
-        return self.get_sequences(content)
+        return Response(
+            json.dumps(self.get_sequences(content)),
+            headerlist=[('Content-Type', 'application/json')],
+            charset='utf8'
+        )
 
     @XBlock.handler
     def transcript(self, request, dispatch):

--- a/labxchange_xblocks/public/js/audio-xblock.js
+++ b/labxchange_xblocks/public/js/audio-xblock.js
@@ -8,7 +8,7 @@ function LXAudioXBlock(runtime, element, init_args) {
         this.toggleElement = this.element.find('.audio-block-transcript-toggle');
         this.currentLang = user_state.current_lang || '';
         this.folded = false;
-        this.getSequencesUrl = user_state.sequences_url;
+        this.getSequencesUrl = runtime.handlerUrl(element, 'sequences');
         this.init();
     }
 
@@ -26,10 +26,8 @@ function LXAudioXBlock(runtime, element, init_args) {
     LanguageSelector.prototype.getSequences = function(lang) {
         var sequencesElement = this.sequencesElement;
         $.ajax({
-            url: this.getSequencesUrl,
-            data: JSON.stringify({'lang': lang}),
-            contentType: 'application/json',
-            method: 'POST',
+            url: this.getSequencesUrl + '?lang=' + lang,
+            method: 'GET',
         }).done(function(data) {
             sequencesElement.html('');
             data.map(function(sequence, index) {


### PR DESCRIPTION
This merge request is about using `GET` method instead of `POST` to retrieve audio sequences.

**Jira tickets**

- [SE-3111](https://tasks.opencraft.com/browse/SE-3111)
- [LX-1294](https://tasks.opencraft.com/browse/LX-1294)

**Testing instructions**

**Testing instructions**

* :warning:️ You need to have [labxchange-xblocks](https://github.com/open-craft/labxchange-xblocks/pull/11) installed before
* Create an audio asset with a Soundcloud embed code
* Edit it and add a transcript
* Add another different transcript
* View the audio asset and check that you can see the different transcripts and change between them
* Check that when you change language, new sequences are retrieved using a `GET` request like that:

```
/api/xblock/v2/xblocks/lb:LabXchange:3877d1c2:lx_audio:1/handler/3-8a2dfb77df1a0847fb40/sequences/?lang=en
```

**Reviewers**

- @s0b0lev 