### PR TITLE
SE-3691 [LX-1723] Hide audio transcripts element if no transcripts

### DIFF
--- a/labxchange_xblocks/audio_block.py
+++ b/labxchange_xblocks/audio_block.py
@@ -84,7 +84,7 @@ class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
             'sequences': sequences,
             'user_state': self.user_state,
         }
-    
+
     @property
     def user_state(self):
         languages = self.transcripts.keys()
@@ -134,7 +134,7 @@ class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
 
                 },
             } for sequence in sequences]
-    
+
     def get_transcript_content(self, url):
         """ Retrieves and returns transcript content from Blockstore """
         response = requests.get(url)

--- a/labxchange_xblocks/templates/audio_student_view.html
+++ b/labxchange_xblocks/templates/audio_student_view.html
@@ -2,6 +2,7 @@
     <div class="audio-block-embed-code-student-view">
         {{ embed_code|safe }}
     </div>
+    {% if options %}
     <div class="audio-block-transcript-student-view">
         <div class="audio-block-transcript-title-student-view">
             <h2>Transcripts</h2>
@@ -20,4 +21,5 @@
         </div>
         <div class="audio-block-sequences-student-view"></div>
     </div>
+    {% endif %}
 </div>


### PR DESCRIPTION
This prevents confusion and buggy views when there are no transcripts,
by hiding the transcripts view entirely if no transcripts to display.

(It also removes some trailing space...)

**Test instructions**:

- create an audio asset with no transcripts
- view and verify that the transcripts element/bar is hidden
- add transcripts to the audio asset
- save and verify correct operation of the transcripts element

**Reviewers**:

- [x] @eLRuLL 

