### PR TITLE
FAL-772 [LX-1827] Ignore missing children in composite blocks

### DIFF
--- a/labxchange_xblocks/assignment_block.py
+++ b/labxchange_xblocks/assignment_block.py
@@ -54,7 +54,7 @@ class AssignmentBlock(
         for child_usage_id in self.children:  # pylint: disable=no-member
             try:
                 child_block = self.runtime.get_block(child_usage_id)
-            except Exception:
+            except ValueError:
                 child_block = None
             if child_block:
                 weight = self._get_weighted_score_possible_for_child(child_block)
@@ -87,7 +87,7 @@ class AssignmentBlock(
         for child_usage_id in self.children:  # pylint: disable=no-member
             try:
                 child_block = self.runtime.get_block(child_usage_id)
-            except Exception:
+            except ValueError:
                 child_block = None
             if child_block:
                 score = self.get_weighted_score_for_block(child_block)

--- a/labxchange_xblocks/assignment_block.py
+++ b/labxchange_xblocks/assignment_block.py
@@ -52,7 +52,10 @@ class AssignmentBlock(
         """
         child_blocks_data = []
         for child_usage_id in self.children:  # pylint: disable=no-member
-            child_block = self.runtime.get_block(child_usage_id)
+            try:
+                child_block = self.runtime.get_block(child_usage_id)
+            except Exception:
+                child_block = None
             if child_block:
                 weight = self._get_weighted_score_possible_for_child(child_block)
                 child_block_data = {
@@ -82,7 +85,10 @@ class AssignmentBlock(
         total_possible = 0
 
         for child_usage_id in self.children:  # pylint: disable=no-member
-            child_block = self.runtime.get_block(child_usage_id)
+            try:
+                child_block = self.runtime.get_block(child_usage_id)
+            except Exception:
+                child_block = None
             if child_block:
                 score = self.get_weighted_score_for_block(child_block)
                 child_blocks_state[str(child_usage_id)] = {'score': score}

--- a/labxchange_xblocks/case_study_block.py
+++ b/labxchange_xblocks/case_study_block.py
@@ -77,7 +77,7 @@ For example: [
         for child_usage_id in self.children:  # pylint: disable=no-member
             try:
                 child_block = self.runtime.get_block(child_usage_id)
-            except Exception:
+            except ValueError:
                 child_block = None
             if child_block:
                 valid_child_block_ids.add(str(child_usage_id))

--- a/labxchange_xblocks/case_study_block.py
+++ b/labxchange_xblocks/case_study_block.py
@@ -75,7 +75,10 @@ For example: [
         child_blocks = []
 
         for child_usage_id in self.children:  # pylint: disable=no-member
-            child_block = self.runtime.get_block(child_usage_id)
+            try:
+                child_block = self.runtime.get_block(child_usage_id)
+            except Exception:
+                child_block = None
             if child_block:
                 valid_child_block_ids.add(str(child_usage_id))
                 child_block_data = {

--- a/labxchange_xblocks/tests/assignment_block_test.py
+++ b/labxchange_xblocks/tests/assignment_block_test.py
@@ -71,3 +71,46 @@ class AssignmentBlockTestCase(XmlTest, BlockTestCaseBase):
             ],
             u'display_name': u'Assignment 1'
         })
+
+    def test_student_view_data_missing_child(self):
+
+        field_data = {
+            'display_name': 'Assignment 1'
+        }
+        block = self._construct_xblock_mock(self.block_class, self.keys, field_data=DictFieldData(field_data))
+
+        document_block_keys = ScopeIds('a_user', 'lx_document', 'def_id_document', 'usage_id_document')
+        document_block = DocumentBlock(self.runtime_mock, scope_ids=document_block_keys, field_data=DictFieldData({
+            'display_name': 'Assignment Document',
+        }))
+        block.children.append(document_block.scope_ids.block_type)
+
+        image_block_keys = ScopeIds('a_user', 'lx_image', 'def_id_image', 'usage_id_image')
+        image_block = self._construct_xblock_mock(ImageBlock, image_block_keys, field_data=DictFieldData({
+            'display_name': 'Assignment Image',
+        }))
+        block.children.append(image_block.scope_ids.block_type)
+
+        def get_block(usage_id):
+            if usage_id == 'lx_document':
+                return document_block
+            if usage_id == 'lx_image':
+                raise ValueError("mock block not found")
+
+        self.runtime_mock.get_block.side_effect = get_block
+
+        data = block.student_view_data(None)
+
+        self.assertDictEqual(data, {
+            u'child_blocks': [
+                {
+                    'block_type': 'lx_document',
+                    'display_name': 'Assignment Document',
+                    'usage_id': 'lx_document',
+                    'graded': False,
+                    'max_attempts': None,
+                    'weight': 0,
+                }
+            ],
+            u'display_name': u'Assignment 1'
+        })

--- a/labxchange_xblocks/utils.py
+++ b/labxchange_xblocks/utils.py
@@ -87,7 +87,10 @@ class StudentViewBlockMixin(XBlockMixin):
         if self.has_children:
             child_blocks_data = []
             for child_usage_id in self.children:
-                child_block = self.runtime.get_block(child_usage_id)
+                try:
+                    child_block = self.runtime.get_block(child_usage_id)
+                except Exception:
+                    child_block = None
                 if child_block:
                     child_block_fragment = child_block.render(child_view, context)
                     child_block_content = child_block_fragment.content
@@ -103,7 +106,7 @@ class StudentViewBlockMixin(XBlockMixin):
 
         if self.css_resource_url:
             fragment.add_css_url(self.runtime.local_resource_url(self, self.css_resource_url))
-        
+
         if self.js_resource_url and self.js_init_function:
             fragment.add_javascript_url(self.runtime.local_resource_url(self, self.js_resource_url))
             fragment.initialize_js(

--- a/labxchange_xblocks/utils.py
+++ b/labxchange_xblocks/utils.py
@@ -89,7 +89,7 @@ class StudentViewBlockMixin(XBlockMixin):
             for child_usage_id in self.children:
                 try:
                     child_block = self.runtime.get_block(child_usage_id)
-                except Exception:
+                except ValueError:
                     child_block = None
                 if child_block:
                     child_block_fragment = child_block.render(child_view, context)


### PR DESCRIPTION
In the case where a child's xblock data was deleted,
we need to gracefully ignore it.

**Test instructions**:

- For each composite xblock (pathway, case study, assignment), delete a child xblock data, and load all the endpoints (including student_view) for the composite xblock.
- verify that the deleted children are not displayed, and that no errors are thrown.


See https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1214 for more information

**Reviewers**:

-  [ ] @symbolist 