### PR TITLE
FAL-880 [LX-1821] Teaching Guide xblock

### DIFF
--- a/.coverage
+++ b/.coverage
@@ -1,1 +1,0 @@
-!coverage.py: This is a private format, don't read it directly!{"lines":{"/edx/src/labxchange-xblocks/labxchange_xblocks/__init__.py":[10,3,12,5,7]}}

--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.6.1'
+__version__ = '0.7.0'
 
 
 def one():

--- a/labxchange_xblocks/case_study_block.py
+++ b/labxchange_xblocks/case_study_block.py
@@ -22,7 +22,7 @@ class CaseStudyBlock(
     XBlockWithPreviewMixin,
 ):
     """
-    XBlock for case studies.
+    XBlock for case studies and teaching guides.
     """
 
     display_name = String(
@@ -95,10 +95,15 @@ For example: [
                     children.append({
                         "inlinehtml": child["inlinehtml"]
                     })
-                elif child.get("usage_id") in valid_child_block_ids:
-                    children.append({
-                        "usage_id": child["usage_id"],
-                    })
+                elif child.get("usage_id"):
+                    # if we're embedding, it needs to be a valid xblock
+                    if child.get("embed", True) and not child["usage_id"] in valid_child_block_ids:
+                        continue
+                    else:
+                        children.append({
+                            "usage_id": child["usage_id"],
+                            "embed": child.get("embed", True),
+                        })
 
             sections.append({
                 "title": section.get("title", ""),
@@ -107,7 +112,7 @@ For example: [
 
         attachments = []
         for xblock_id in self.attachments:
-            if isinstance(xblock_id, str) and xblock_id in valid_child_block_ids:
+            if isinstance(xblock_id, str):
                 attachments.append(xblock_id)
 
         return {

--- a/labxchange_xblocks/templates/case_study_student_view.html
+++ b/labxchange_xblocks/templates/case_study_student_view.html
@@ -10,9 +10,15 @@
                         {{ child.inlinehtml|safe }}
                     </div>
                 {% else %}
-                    <div class="case-study-block-child case-study-block-child-content">
-                        {{ child_blocks|get_xblock_content:child.usage_id|safe }}
-                    </div>
+                    {% if child.embed %}
+                        <div class="case-study-block-child case-study-block-child-content">
+                            {{ child_blocks|get_xblock_content:child.usage_id|safe }}
+                        </div>
+                    {% else %}
+                        <div class="case-study-block-child case-study-block-child-content">
+                            Non-embedded asset with id: {{ child.usage_id }}
+                        </div>
+                    {% endif %}
                 {% endif %}
             {% endfor %}
         </section>

--- a/labxchange_xblocks/tests/audio_block_test.py
+++ b/labxchange_xblocks/tests/audio_block_test.py
@@ -31,16 +31,7 @@ class AudioBlockTestCase(BlockTestCaseBase):
     <div class="audio-block-embed-code-student-view">
         
     </div>
-    <div class="audio-block-transcript-student-view">
-        <div class="audio-block-transcript-title-student-view">
-            <h2>Transcripts</h2>
-            <select class="audio-block-transcript-select">
-                
-            </select>
-            <button class="audio-block-transcript-toggle"></button>
-        </div>
-        <div class="audio-block-sequences-student-view"></div>
-    </div>
+    
 </div>
 """
             ),
@@ -66,16 +57,7 @@ class AudioBlockTestCase(BlockTestCaseBase):
     <div class="audio-block-embed-code-student-view">
         <iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
     </div>
-    <div class="audio-block-transcript-student-view">
-        <div class="audio-block-transcript-title-student-view">
-            <h2>Transcripts</h2>
-            <select class="audio-block-transcript-select">
-                
-            </select>
-            <button class="audio-block-transcript-toggle"></button>
-        </div>
-        <div class="audio-block-sequences-student-view"></div>
-    </div>
+    
 </div>
 """
             ),

--- a/labxchange_xblocks/tests/case_study_block_test.py
+++ b/labxchange_xblocks/tests/case_study_block_test.py
@@ -19,6 +19,7 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
 
     block_type = "lx_case_study"
     block_class = CaseStudyBlock
+    maxDiff = None
 
     def test_is_aggregator(self):
         self.assertEqual(
@@ -91,11 +92,11 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     "title": "Section One",
                     "children": [
                         {"inlinehtml": "<span>hello</span>"},
-                        {"usage_id": "lx_image"},
+                        {"usage_id": "lx_image", "embed": True},
                         {
                             "inlinehtml": ["ignore", "this"]
                         },  # invalid type here will be dropped from output
-                        {"usage_id": "lx_image"},  # dups are ok here
+                        {"usage_id": "lx_image", "embed": True},  # dups are ok here
                     ],
                 },
                 {
@@ -114,8 +115,8 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     "title": "Section One",
                     "children": [
                         {"inlinehtml": "<span>hello</span>"},
-                        {"usage_id": "lx_image"},
-                        {"usage_id": "lx_image"},  # dups are ok here
+                        {"usage_id": "lx_image", "embed": True},
+                        {"usage_id": "lx_image", "embed": True},  # dups are ok here
                     ],
                 },
                 {"title": "Section Two", "children": [{"inlinehtml": ""},],},
@@ -128,7 +129,7 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     "title": "Section One",
                     "children": [
                         {"inlinehtml": "<span>hello</span>"},
-                        {"usage_id": "lx_image"},
+                        {"usage_id": "lx_image", "embed": True},
                     ],
                 },
                 {
@@ -142,7 +143,7 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     "title": "Section One",
                     "children": [
                         {"inlinehtml": "<span>hello</span>"},
-                        {"usage_id": "lx_image"},
+                        {"usage_id": "lx_image", "embed": True},
                     ],
                 },
                 {
@@ -154,12 +155,13 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
         ),
         ([], ["lx_image"], [], ["lx_image"],),
         ([], ["lx_document", "lx_image"], [], ["lx_document", "lx_image"],),
-        # invalid/notfound attachments are dropped
+        # invalid/notfound attachments are kept because they may be non-xblock attachments
+        # (eg. a labxchange native asset)
         (
             [],
             ["lx_document", "does_not_exist", "lx_image"],
             [],
-            ["lx_document", "lx_image"],
+            ["lx_document", "does_not_exist", "lx_image"],
         ),
         (
             [],

--- a/labxchange_xblocks/tests/document_block_test.py
+++ b/labxchange_xblocks/tests/document_block_test.py
@@ -24,7 +24,7 @@ class DocumentBlockTestCase(BlockTestCaseBase):
             },
             (
                 '<div class="document-block-student-view">\n'
-                '<object aria-label="Document" data="" type="application/pdf">\n'
+                '<object data="" type="application/pdf" aria-label="Document">\n'
                 '<p>It appears you don\'t have an appropriate viewer plugin installed.'
                 ' Click <a href="">here</a> to view the file.</p>\n'
                 '</object>\n'
@@ -45,7 +45,7 @@ class DocumentBlockTestCase(BlockTestCaseBase):
             },
             (
                 '<div class="document-block-student-view">\n'
-                '<object aria-label="Stars - ستارے" data="https://cdn.org/stars.jpeg" type="text/html">\n'
+                '<object data="https://cdn.org/stars.jpeg" type="text/html" aria-label="Stars - ستارے">\n'
                 '<p>It appears you don\'t have an appropriate viewer plugin installed.'
                 ' Click <a href="https://cdn.org/stars.jpeg">here</a> to view the file.</p>\n'
                 '</object>\n'

--- a/labxchange_xblocks/tests/image_block_test.py
+++ b/labxchange_xblocks/tests/image_block_test.py
@@ -28,7 +28,7 @@ class ImageBlockTestCase(BlockTestCaseBase):
             # And this HTML:
             (
                 '<figure class="image-block-student-view">\n'
-                '<img alt="" class="image-block-image" src=""/>\n'
+                '<img class="image-block-image" src="" alt=""/>\n'
                 '</figure>'
             )
         ), (
@@ -51,8 +51,8 @@ class ImageBlockTestCase(BlockTestCaseBase):
             # And this HTML:
             (
                 '<figure class="image-block-student-view">\n'
-                '<img alt="Map of the moon - چاند کا نقشہ" class="image-block-image"\n'
-                ' src="https://cdn.org/moon.jpeg"/>\n'
+                '<img class="image-block-image" src="https://cdn.org/moon.jpeg"\n'
+                ' alt="Map of the moon - چاند کا نقشہ"/>\n'
                 '<figcaption>\n'
                 '<span class="caption">Fig. 1: Map of the moon - چاند کا نقشہ</span>\n'
                 '<cite>Courtesy NASA Lunar Reconnaissance Orbiter science team</cite>\n'

--- a/labxchange_xblocks/tests/simulation_block_test.py
+++ b/labxchange_xblocks/tests/simulation_block_test.py
@@ -22,7 +22,7 @@ class SimulationBlockTestCase(BlockTestCaseBase):
             },
             (
                 '<div class="simulation-block-student-view">\n'
-                '<iframe src="" title="Simulation">\n</iframe>\n'
+                '<iframe title="Simulation" src="">\n</iframe>\n'
                 '</div>'
             ),
         ), (
@@ -36,7 +36,7 @@ class SimulationBlockTestCase(BlockTestCaseBase):
             },
             (
                 '<div class="simulation-block-student-view">\n'
-                '<iframe src="https://cdn.org/galaxy.jpeg" title="A galaxy - ایک کہکشاں">\n</iframe>\n'
+                '<iframe title="A galaxy - ایک کہکشاں" src="https://cdn.org/galaxy.jpeg">\n</iframe>\n'
                 '</div>'
             ),
         )

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ setup(
             'lx_image = labxchange_xblocks.image_block:ImageBlock',
             'lx_narrative = labxchange_xblocks.narrative_block:NarrativeBlock',
             'lx_simulation = labxchange_xblocks.simulation_block:SimulationBlock',
+            'lx_teaching_guide = labxchange_xblocks.case_study_block:CaseStudyBlock',
         ]
     },
 )


### PR DESCRIPTION
[FAL-880](https://tasks.opencraft.com/browse/FAL-880)

This adds support for the teaching guide xblock.  It also fixes a bunch of unrelated broken tests.

**Test instructions**:

- install this in your devstack
- verify that tests pass
- continue testing with [opencraft/client/LabXchange/labxchange-dev#1319](https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1319)

**Reviewers**:

- [ ] @symbolist 