### PR TITLE
[FAL-2117]  Return Youtube video ID with Annotated video xblock data

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 
 
 def one():

--- a/labxchange_xblocks/annotated_video_block.py
+++ b/labxchange_xblocks/annotated_video_block.py
@@ -132,7 +132,8 @@ class AnnotatedVideoBlock(
             state.update({
                 "video_poster": settings.YOUTUBE['IMAGE_API'].format(
                     youtube_id=video_block.youtube_id_1_0,
-                )
+                ),
+                "video_youtube_id": video_block.youtube_id_1_0,
             })
 
         return Response(


### PR DESCRIPTION
This pull request is about returning the youtube video ID along with other view data so that the LX frontend can query the YouTube API to get extra details.

Note: This pull request should also increase the version number.

**Jira tickets**

- [FAL-2117](https://tasks.opencraft.com/browse/FAL-2117)

**Testing instructions**

Should be tested while reviewing internal PRs.

**Reviewers**

- [ ] @swalladge 