### PR TITLE
FAL-2482 [LX-2242] 

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 
 
 def one():

--- a/labxchange_xblocks/public/js/audio-xblock.js
+++ b/labxchange_xblocks/public/js/audio-xblock.js
@@ -1,3 +1,4 @@
+// TODO: delete this once https://tasks.opencraft.com/browse/LX-2243 is complete
 function LXAudioXBlock(runtime, element, init_args) {
     'use strict';
 
@@ -29,19 +30,7 @@ function LXAudioXBlock(runtime, element, init_args) {
             url: this.getSequencesUrl + '?lang=' + lang,
             method: 'GET',
         }).done(function(data) {
-            sequencesElement.html('');
-            data.map(function(sequence, index) {
-                sequencesElement.append(
-                    `<div class="audio-block-sequences-line-student-view ${index == 0 ? 'first-line' : ''}">` +
-                        '<div class="audio-block-sequences-start-student-view">' +
-                            `${sequence.start.hours}:${sequence.start.minutes}:${sequence.start.seconds}` +
-                        '</div>' +
-                        '<div class="audio-block-sequences-text-student-view">' +
-                            `${sequence.text}` +
-                        '</div>' +
-                    '</div>'
-                );
-            })
+            sequencesElement.html(data.content);
         });
     }
 

--- a/labxchange_xblocks/tests/audio_block_test.py
+++ b/labxchange_xblocks/tests/audio_block_test.py
@@ -29,7 +29,6 @@ class AudioBlockTestCase(BlockTestCaseBase):
                 'display_name': 'Audio',
                 'embed_code': '',
                 'options': [],
-                'sequences': [],
                 'transcripts': {},
                 'user_state': {'current_language': None},
             },
@@ -46,8 +45,6 @@ class AudioBlockTestCase(BlockTestCaseBase):
             {
                 'display_name': 'A very cool track',
                 'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
-                'options': [],
-                'sequences': [],
                 'transcripts': {},
                 'user_state': {'current_language': None},
             },
@@ -55,7 +52,6 @@ class AudioBlockTestCase(BlockTestCaseBase):
                 'display_name': 'A very cool track',
                 'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
                 'options': [],
-                'sequences': [],
                 'transcripts': {},
                 'user_state': {'current_language': None},
             },
@@ -85,3 +81,59 @@ class AudioBlockTestCase(BlockTestCaseBase):
         self.assertEqual(fragment.content, expected_html)
         fragment = block.public_view(None)
         self.assertEqual(fragment.content, expected_html)
+
+    def test_inline_transcripts(self):
+        # test that inline transcripts are processed as expected,
+        # as well as testing that the on-the-fly conversion of srt files to inline html is done as expected
+        field_data = {
+            'display_name': 'A very cool track',
+            'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
+            'transcripts': {
+                'en': {
+                    'type': 'inlinehtml',
+                    'content': '<p>Welcome to the show</p>',
+                },
+                'fr': 'transcript-fr.srt',
+            },
+            'user_state': {'current_language': None},
+        }
+
+        expected_data = {
+            'display_name': 'A very cool track',
+            'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
+            'options': [
+                {'lang': 'en', 'language': {'name': 'English', 'native_name': 'English'}},
+                {'lang': 'fr', 'language': {'name': 'French', 'native_name': 'français, langue française'}}
+            ],
+            'transcripts': {
+                'en': {
+                    'type': 'inlinehtml',
+                    'content': '<p>Welcome to the show</p>',
+                },
+                'fr': {
+                    'type': 'inlinehtml',
+                    'content': '<p>Bienvenue !</p>',
+                },
+            },
+            'user_state': {'current_language': 'en'},
+        }
+
+        example_srt = b'''
+1
+00:00:00,000 --> 00:00:04,440
+Bienvenue !
+        '''
+
+        block = self._construct_xblock_mock(self.block_class, self.keys, field_data=DictFieldData(field_data))
+
+        # mocking assets retrieval to make the transcripts code work in this test
+        block.get_transcript_asset = lambda x: MockAsset('fr.url') if x == 'fr' else None
+        block.get_transcript_content = lambda x: example_srt if x == 'fr.url' else 'whatever'
+
+        data = block.student_view_data(None)
+        assert data == expected_data
+
+
+class MockAsset:
+    def __init__(self, url):
+        self.url = url


### PR DESCRIPTION
[FAL-2482](https://tasks.opencraft.com/browse/FAL-2482) | [LX-2242](https://tasks.opencraft.com/browse/LX-2242)

These changes are to support the transition from srt subtitles to inline html transcripts for audio blocks.

**Test instructions**:

- test as part of [opencraft/client/LabXchange/labxchange-dev!1532](https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1532)
- read the code and verify the logic is correct and desirable