### PR TITLE
Adding student_view_user_state for audio transcripts

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.8.4'
+__version__ = '0.8.5'
 
 
 def one():

--- a/labxchange_xblocks/audio_block.py
+++ b/labxchange_xblocks/audio_block.py
@@ -143,6 +143,19 @@ class AudioBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         return response.content
 
     @XBlock.handler
+    def student_view_user_state(
+        self, request, suffix=""
+    ):  # pylint: disable=unused-argument
+        """
+        Return JSON representation of the block with enough data to render the student view.
+        Also, we can use this endpoint to render the view somewhere else
+        """
+        state = self.student_view_data()
+        return Response(
+            json.dumps(state), content_type="application/json", charset="UTF-8"
+        )
+
+    @XBlock.handler
     def sequences(self, request, dispatch):  # pylint: disable=unused-argument
         """
         Returns sequences based on lang parameter.


### PR DESCRIPTION
**Description**

- [FAL-2483](https://tasks.opencraft.com/browse/FAL-2483)
- [LX-2243](https://tasks.opencraft.com/browse/LX-2243)

As a part of LX-2243, we are removing the transcript view for the audio xblock.
Transcript will no longer be shown in the xblock.
But for the first phase of deployment, we are just adding the student_view_handler so that the above is possible

**Testing Instructions**
1. Add the labxchange xblock into your labxchange devstack.
2. Add a new audio along with a transcript and save the video
3. Check the json is successfully returned via `student_view_user_state`