### PR TITLE
Updates to image content type

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 
 
 def one():

--- a/labxchange_xblocks/image_block.py
+++ b/labxchange_xblocks/image_block.py
@@ -49,7 +49,7 @@ class ImageBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         scope=Scope.content,
     )
 
-    extendDesc = String(
+    extended_desc = String(
         display_name=_('Extended Description'),
         help=_('Extended description for the image. Optional.'),
         default='',

--- a/labxchange_xblocks/image_block.py
+++ b/labxchange_xblocks/image_block.py
@@ -49,12 +49,20 @@ class ImageBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
         scope=Scope.content,
     )
 
+    extendDesc = String(
+        display_name=_('Extended Description'),
+        help=_('Extended description for the image. Optional.'),
+        default='',
+        scope=Scope.content,
+    )
+
     editable_fields = (
         'display_name',
         'alt_text',
         'image_url',
         'caption',
         'citation',
+        'extended_desc',
     )
 
     student_view_template = 'templates/image_student_view.html'
@@ -70,4 +78,5 @@ class ImageBlock(XBlock, StudioEditableXBlockMixin, StudentViewBlockMixin):
             'image_url': self.expand_static_url(self.image_url),
             'caption': self.caption,
             'citation': self.citation,
+            'extended_desc': self.extended_desc,
         }

--- a/labxchange_xblocks/tests/image_block_test.py
+++ b/labxchange_xblocks/tests/image_block_test.py
@@ -29,6 +29,7 @@ class ImageBlockTestCase(BlockTestCaseBase):
                 'image_url': '',
                 'caption': '',
                 'citation': '',
+                'extended_desc': '',
             },
             # And this HTML:
             (
@@ -44,6 +45,7 @@ class ImageBlockTestCase(BlockTestCaseBase):
                 'image_url': 'https://cdn.org/moon.jpeg',
                 'caption': 'Fig. 1: Map of the moon - چاند کا نقشہ',
                 'citation': 'Courtesy NASA Lunar Reconnaissance Orbiter science team',
+                'extended_desc': 'I am the extended description',
             },
             # Then we expect this student_view_data output:
             {
@@ -52,6 +54,7 @@ class ImageBlockTestCase(BlockTestCaseBase):
                 'image_url': 'https://cdn.org/moon.jpeg',
                 'caption': 'Fig. 1: Map of the moon - چاند کا نقشہ',
                 'citation': 'Courtesy NASA Lunar Reconnaissance Orbiter science team',
+                'extended_desc': 'I am the extended description',
             },
             # And this HTML:
             (


### PR DESCRIPTION
**Description**

- [FAL-2631](https://tasks.opencraft.com/browse/FAL-2631)
- [LX-2094](https://tasks.opencraft.com/browse/LX-2094)

As a part of LX-2094, we want to support extended description for an image block

**Testing Instructions**
1. Add the labxchange xblock into your labxchange devstack.
2. Add a new image along with an extended description
3. Check that the extended description is visible on LX website