### PR TITLE
[LX-2552]: Fix `annotated_video` and `audio` blocks in pathways

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 
 def one():

--- a/labxchange_xblocks/annotated_video_block.py
+++ b/labxchange_xblocks/annotated_video_block.py
@@ -126,7 +126,7 @@ class AnnotatedVideoBlock(
                 # We can assume there's going to be only one video
                 # associated with the annotated video block to avoid calculating
                 # the replica id when using this in pathways.
-                if any(block_type in str(child_usage_id) for block_type in ["video", "lx_video"]):
+                if block_type in ["video", "lx_video"]:
                     video_block = child_block
                 child_block_data = {
                     "usage_id": str(child_usage_id),

--- a/labxchange_xblocks/annotated_video_block.py
+++ b/labxchange_xblocks/annotated_video_block.py
@@ -123,7 +123,10 @@ class AnnotatedVideoBlock(
 
             if child_block:
                 block_type = child_block.scope_ids.block_type
-                if str(child_usage_id) == self.video_id:
+                # We can assume there's going to be only one video
+                # associated with the annotated video block to avoid calculating
+                # the replica id when using this in pathways.
+                if any(block_type in str(child_usage_id) for block_type in ["video", "lx_video"]):
                     video_block = child_block
                 child_block_data = {
                     "usage_id": str(child_usage_id),

--- a/labxchange_xblocks/tests/annotated_video_block_test.py
+++ b/labxchange_xblocks/tests/annotated_video_block_test.py
@@ -90,5 +90,7 @@ class AnnotatedVideoBlockTestCase(XmlTest, BlockTestCaseBase):
                         "image_url": "/static/image.png",
                     }
                 ],
+                'video_poster': 'http://img.youtube.com/vi/3_yD_cEKoCk/0.jpg',
+                'video_youtube_id': '3_yD_cEKoCk',
             },
         )

--- a/labxchange_xblocks/tests/audio_block_test.py
+++ b/labxchange_xblocks/tests/audio_block_test.py
@@ -72,19 +72,10 @@ class AudioBlockTestCase(BlockTestCaseBase):
     def test_student_view_data(self, field_data, expected_data, _expected_html):
         self._test_student_view_data(field_data, expected_data)
 
-    @ddt.data(*data)
-    @ddt.unpack
-    def test_student_view(self, field_data, _expected_data, expected_html):
-        block = self._construct_xblock_mock(self.block_class, self.keys, field_data=DictFieldData(field_data))
-
-        fragment = block.student_view(None)
-        self.assertEqual(fragment.content, expected_html)
-        fragment = block.public_view(None)
-        self.assertEqual(fragment.content, expected_html)
-
     def test_inline_transcripts(self):
-        # test that inline transcripts are processed as expected,
-        # as well as testing that the on-the-fly conversion of srt files to inline html is done as expected
+        """
+        Tests that inline transcripts are processed as expected.
+        """
         field_data = {
             'display_name': 'A very cool track',
             'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
@@ -102,32 +93,17 @@ class AudioBlockTestCase(BlockTestCaseBase):
             'embed_code': '<iframe width="100%" height="300" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/794640376&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>',  # noqa: E501
             'options': [
                 {'lang': 'en', 'language': {'name': 'English', 'native_name': 'English'}},
-                {'lang': 'fr', 'language': {'name': 'French', 'native_name': 'français, langue française'}}
             ],
             'transcripts': {
                 'en': {
                     'type': 'inlinehtml',
                     'content': '<p>Welcome to the show</p>',
                 },
-                'fr': {
-                    'type': 'inlinehtml',
-                    'content': '<p>Bienvenue !</p>',
-                },
             },
             'user_state': {'current_language': 'en'},
         }
 
-        example_srt = b'''
-1
-00:00:00,000 --> 00:00:04,440
-Bienvenue !
-        '''
-
         block = self._construct_xblock_mock(self.block_class, self.keys, field_data=DictFieldData(field_data))
-
-        # mocking assets retrieval to make the transcripts code work in this test
-        block.get_transcript_content = lambda x: example_srt if x == 'fr.url' else 'whatever'
-
         data = block.student_view_data(None)
         assert data == expected_data
 

--- a/labxchange_xblocks/tests/audio_block_test.py
+++ b/labxchange_xblocks/tests/audio_block_test.py
@@ -93,7 +93,6 @@ class AudioBlockTestCase(BlockTestCaseBase):
                     'type': 'inlinehtml',
                     'content': '<p>Welcome to the show</p>',
                 },
-                'fr': 'transcript-fr.srt',
             },
             'user_state': {'current_language': None},
         }
@@ -127,7 +126,6 @@ Bienvenue !
         block = self._construct_xblock_mock(self.block_class, self.keys, field_data=DictFieldData(field_data))
 
         # mocking assets retrieval to make the transcripts code work in this test
-        block.get_transcript_asset = lambda x: MockAsset('fr.url') if x == 'fr' else None
         block.get_transcript_content = lambda x: example_srt if x == 'fr.url' else 'whatever'
 
         data = block.student_view_data(None)

--- a/labxchange_xblocks/tests/video_block_test.py
+++ b/labxchange_xblocks/tests/video_block_test.py
@@ -82,7 +82,7 @@ class VideoBlockTestCase(BlockTestCaseBase):
                 },
                 "saved_video_position": 0.0,
                 "speed": None,
-                "transcripts": {"en": "transcript/download"},
+                "transcripts": {"en": "transcript/download/lang=en"},
             },
         ),
         (
@@ -100,7 +100,7 @@ class VideoBlockTestCase(BlockTestCaseBase):
                 "saved_video_position": 0.0,
                 "speed": 1.5,
                 "saved_video_position": 90.0,
-                "transcripts": {"en": "transcript/download"},
+                "transcripts": {"en": "transcript/download/lang=en"},
             },
         ),
     )
@@ -145,44 +145,3 @@ class VideoBlockTestCase(BlockTestCaseBase):
             self.block_class, self.keys, field_data=DictFieldData(field_data)
         )
         assert block.get_transcripts_info() == expected_data
-
-    @ddt.data(
-        (
-            {
-                "content": "test_content",
-                "filename": "my-file.srt",
-                "language": "en",
-                "content_type": "application/json",
-            },
-        ), (
-            {
-                "content": "test_content",
-                "filename": "my-file.srt",
-                "language": "en",
-                "content_type": "application/json",
-                "add_attachment_header": False,
-            },
-        ), (
-            {
-                "content": "test_content",
-                "filename": "my-file.srt",
-                "language": "fr",
-                "content_type": "application/json",
-                "add_attachment_header": True,
-            },
-        )
-    )
-    @ddt.unpack
-    def test_make_transcript_http_response(self, parameters):
-        block = self._construct_xblock_mock(
-            self.block_class, self.keys, field_data=DictFieldData({})
-        )
-        response = block.make_transcript_http_response(**parameters)
-        assert response.text == parameters.get('content')
-        assert ('Content-Language', parameters.get('language')) in response.headerlist
-        assert ('Content-Length', str(len(response.text))) in response.headerlist
-        assert ('Content-Type', parameters.get('content_type')) in response.headerlist
-        if parameters.get('add_attachment_header'):
-            assert (
-                'Content-Disposition',
-                f'attachment; filename=\"{parameters.get("filename")}\"') in response.headerlist


### PR DESCRIPTION
This merge request fixes two XBlocks that don't work properly on pathways:

1. `lx_audio`: removed code cruft and dependencies on transcript files (not used anymore).
2. `annotated_video`: fixed code that locates child video block to work in a generic way.

**Jira tickets**

- [FAL-2925](https://tasks.opencraft.com/browse/FAL-2925)
- [LX-2552](https://tasks.opencraft.com/browse/LX-2552)


**Testing instructions**
1. Install this branch on your devstack.
2. Check that `lx_audio` and `annotated_videos` continue working from the library (http://localhost:4556/library/items/lb:LabXchange:1109ec43:lx_annotated_video:1 and http://localhost:4556/library/items/lb:LabXchange:1f29b8d5:lx_audio:1).
3. Check that the modified blocks retain their behavior when logged out.
4. Create a pathways adding those two items and check that they work.

**Author's notes and concerns**

1. I also took the opportunity to fix the tests and remove unused bits of code!

**Release notes**

Release as usual - this will only fix the currently broken blocks.

**Reviewers**

- [ ] @pomegranited 