### PR TITLE
Fixes issues introduced by using lx_block_types for select users

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 
 
 def one():

--- a/labxchange_xblocks/utils.py
+++ b/labxchange_xblocks/utils.py
@@ -80,8 +80,16 @@ class StudentViewBlockMixin(XBlockMixin):
         """
         Returns LX_BLOCK_TYPES_OVERRIDE if lx_block_types=1 is part of the request.
         """
+        # Deal with the many types of request objects that might come through here
+        if hasattr(request, 'url'):  # WebOb
+            url = request.url
+        elif hasattr(request, 'get_full_path'):  # HttpRequest
+            url = request.get_full_path()
+        else:
+            url = ''
+
         block_type_overrides = None
-        if 'lx_block_types=1' in request.url:
+        if 'lx_block_types=1' in url:
             block_type_overrides = LX_BLOCK_TYPES_OVERRIDE
         return block_type_overrides
 


### PR DESCRIPTION
Patch to the previous https://github.com/open-craft/labxchange-xblocks/pull/35, which allows xblock handlers to be called with a Django HttpRequest from within the LabXchange views.
Also fixes a bug caused by block caching and switching between using LX block types and edX block types.

Bumps version to `0.9.3`.

**Testing instructions**

Can be tested with https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1684

**Author Notes & Concerns**

1. Needs to be deployed to edx-platform prior to enabling use of the LX runtime or lx block types.