### PR TITLE
LX-2480 fix: handles requests from LX's XBlockRuntime

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 
 
 def one():

--- a/labxchange_xblocks/fields.py
+++ b/labxchange_xblocks/fields.py
@@ -18,8 +18,16 @@ class RelativeTime(JSONField):
     @classmethod
     def isotime_to_timedelta(cls, value):
         """
-        Validate the "HH:MM:SS" format.
+        Convert integers and strings to the "HH:MM:SS" format.
         """
+        try:
+            # Convert integers into a formatted time string.
+            value = int(value)
+            value = time.strftime('%H:%M:%S', time.gmtime(int(value)))
+        except ValueError as e:
+            # Skip these -- we'll catch them below
+            pass
+
         try:
             obj_time = time.strptime(value, "%H:%M:%S")
         except ValueError as e:
@@ -43,13 +51,7 @@ class RelativeTime(JSONField):
         if isinstance(value, datetime.timedelta):
             return value
 
-        if isinstance(value, float):
-            return datetime.timedelta(seconds=value)
-
-        if isinstance(value, str):
-            return self.isotime_to_timedelta(value)
-
-        raise TypeError(f"RelativeTime Field {self.name} has bad value '{value!r}'")
+        return self.isotime_to_timedelta(value)
 
     def to_json(self, value):
         """

--- a/labxchange_xblocks/video_block.py
+++ b/labxchange_xblocks/video_block.py
@@ -162,11 +162,11 @@ class VideoBlock(XBlock, StudentViewBlockMixin):
     def xmodule_handler(self, request, suffix=None):
         """Catchall handler for the xmodule path"""
 
-        data = MultiDict(request.POST)
+        data = MultiDict(request.POST or request.data)
         response_data = {"success": False}
         conversions = {
             "saved_video_position": RelativeTime.isotime_to_timedelta,
-            "speed": json.loads,
+            "speed": lambda s: json.loads(str(s)),
             "transcript_language": lambda s: s,
         }
 


### PR DESCRIPTION
LX calls the XBlock handler directly, and uses a slightly different request format.
This change handles that difference.

To be tested as part of https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1705
