### PR TITLE
fix: handles transcript requests from LX's XBlockRuntime

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,7 +4,7 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 
 
 def one():

--- a/labxchange_xblocks/tests/annotated_video_block_test.py
+++ b/labxchange_xblocks/tests/annotated_video_block_test.py
@@ -9,8 +9,8 @@ from xblock.test.test_parsing import XmlTest
 from xmodule.tests.test_import import DummySystem
 from xmodule.video_module import VideoBlock
 
-from labxchange_xblocks.annotated_video_block import AnnotatedVideoBlock
-from labxchange_xblocks.tests.utils import BlockTestCaseBase
+from ..annotated_video_block import AnnotatedVideoBlock
+from ..tests.utils import BlockTestCaseBase
 
 
 class AnnotatedVideoBlockTestCase(XmlTest, BlockTestCaseBase):

--- a/labxchange_xblocks/video_block.py
+++ b/labxchange_xblocks/video_block.py
@@ -231,11 +231,11 @@ class VideoBlock(XBlock, StudentViewBlockMixin):
                     )
                 except Exception as err:  # pylint: disable=broad-except
                     raise NotFoundError(
-                        f"Transcript file '{path}' missing for video XBlock {self.scope_ids.usage_id}"
+                        f"Transcript file '{filename}' missing for video XBlock {self.scope_ids.usage_id}"
                     ) from err
             else:
                 raise NotFoundError(
-                    "Unable to load transcript file '{path}' for video XBlock {self.scope_ids.usage_id}: "
+                    "Unable to load transcript file '{filename}' for video XBlock {self.scope_ids.usage_id}: "
                     "blockstore service not available"
                 )
         # Now convert the transcript data to the requested format:
@@ -312,14 +312,16 @@ class VideoBlock(XBlock, StudentViewBlockMixin):
     def transcript(self, request, dispatch):  # pylint: disable=unused-argument
         """Handler for transcripts"""
         transcripts = self.get_transcripts_info()
-
-        path = request.path_info
-        params = request.params
-
         if dispatch.startswith("translation"):
+            path = request.path_info
             language = path.replace("translation", "").strip("/")
             return self.handle_transcript_translation(request, transcripts, language)
         elif dispatch.startswith("download"):
+            params = {}
+            if hasattr(request, 'params'):
+                params = request.params
+            elif hasattr(request, 'query_params'):
+                params = request.query_params
             lang = params.get("lang", None)
             return self.handle_transcript_download(transcripts, lang)
         else:


### PR DESCRIPTION
LX calls the XBlock handler directly, and uses a slightly different request object.
This change handles that difference.

**Testing instructions**

To be tested as part of https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1705