### PR TITLE
Case Studies/Teaching Guides return original item usage_ids for their children

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,9 +4,4 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.9.8'
-
-
-def one():
-    """Return 1."""
-    return 1
+__version__ = '0.10.0'

--- a/labxchange_xblocks/tests/case_study_block_test.py
+++ b/labxchange_xblocks/tests/case_study_block_test.py
@@ -58,7 +58,7 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
         )
         block.children.append(image_block.scope_ids.block_type)
 
-        def get_block(usage_id, block_type_overrides):
+        def get_block(usage_id, block_type_overrides, use_original):
             if usage_id == "lx_document":
                 return document_block
             if usage_id == "lx_image":
@@ -75,12 +75,12 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     {
                         "block_type": "lx_document",
                         "display_name": "CS Document",
-                        "usage_id": "lx_document",
+                        "usage_id": "usage_id_document",
                     },
                     {
                         "block_type": "lx_image",
                         "display_name": "CS Image",
-                        "usage_id": "lx_image",
+                        "usage_id": "usage_id_image",
                     },
                 ],
                 "display_name": "Case Study 1",
@@ -119,8 +119,8 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     "title": "Section One",
                     "children": [
                         {"inlinehtml": "<span>hello</span>"},
-                        {"usage_id": "lx_image", "embed": True},
-                        {"usage_id": "lx_image", "embed": True},  # dups are ok here
+                        {"usage_id": "usage_id_image", "embed": True},
+                        {"usage_id": "usage_id_image", "embed": True},  # dups are ok here
                     ],
                 },
                 {"title": "Section Two", "children": [{"inlinehtml": ""}, ], },
@@ -147,7 +147,7 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     "title": "Section One",
                     "children": [
                         {"inlinehtml": "<span>hello</span>"},
-                        {"usage_id": "lx_image", "embed": True},
+                        {"usage_id": "usage_id_image", "embed": True},
                     ],
                 },
                 {
@@ -214,7 +214,7 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
         block.sections = sections
         block.attachments = attachments
 
-        def get_block(usage_id, block_type_overrides):
+        def get_block(usage_id, block_type_overrides, use_original):
             if usage_id == "lx_document":
                 return document_block
             if usage_id == "lx_image":
@@ -231,12 +231,12 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     {
                         "block_type": "lx_document",
                         "display_name": "CS Document",
-                        "usage_id": "lx_document",
+                        "usage_id": "usage_id_document",
                     },
                     {
                         "block_type": "lx_image",
                         "display_name": "CS Image",
-                        "usage_id": "lx_image",
+                        "usage_id": "usage_id_image",
                     },
                 ],
                 "display_name": "Case Study 3",
@@ -284,7 +284,7 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
             block.attachments = "foo"
         block.attachments = ["lx_image"]
 
-        def get_block(usage_id, block_type_overrides):
+        def get_block(usage_id, block_type_overrides, use_original):
             if usage_id == "lx_document":
                 return document_block
             if usage_id == "lx_image":
@@ -301,12 +301,12 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                     {
                         "block_type": "lx_document",
                         "display_name": "CS Document",
-                        "usage_id": "lx_document",
+                        "usage_id": "usage_id_document",
                     },
                     {
                         "block_type": "lx_image",
                         "display_name": "CS Image",
-                        "usage_id": "lx_image",
+                        "usage_id": "usage_id_image",
                     },
                 ],
                 "display_name": "Case Study 4",


### PR DESCRIPTION
We're transitioning away from using replica items for XBlock children.

This PR modifies Case Study-like XBlocks to return original asset `usage_id`s instead of replica `usage_id`s for their child items (attachments and embedded).

**Jira tickets**

* [FAL-3181](https://tasks.opencraft.com/browse/FAL-3181)
* [LX-2807](https://tasks.opencraft.com/browse/LX-2807)

**Testing instructions**

See https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/1835 for manual testing instructions.

See [README#Testing on devstack](https://github.com/open-craft/labxchange-xblocks#testing-on-devstack) to check unit tests.