### PR TITLE
Case Studies/Teaching Guides return original item usage_ids

### DIFF
--- a/labxchange_xblocks/__init__.py
+++ b/labxchange_xblocks/__init__.py
@@ -4,4 +4,4 @@ XBlocks developed for the LabXchange project.
 
 from __future__ import absolute_import, unicode_literals
 
-__version__ = '0.10.0'
+__version__ = '0.10.1'

--- a/labxchange_xblocks/case_study_block.py
+++ b/labxchange_xblocks/case_study_block.py
@@ -138,7 +138,7 @@ For example: [
         attachments = []
         for xblock_id in self.attachments:
             if isinstance(xblock_id, str):
-                attachments.append(xblock_id)
+                attachments.append(str(valid_child_block_ids.get(xblock_id, xblock_id)))
 
         return {
             "display_name": self.display_name,

--- a/labxchange_xblocks/tests/case_study_block_test.py
+++ b/labxchange_xblocks/tests/case_study_block_test.py
@@ -157,28 +157,28 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
             ],
             [],
         ),
-        ([], ["lx_image"], [], ["lx_image"],),
-        ([], ["lx_document", "lx_image"], [], ["lx_document", "lx_image"],),
+        ([], ["lx_image"], [], ["usage_id_image"],),
+        ([], ["lx_document", "lx_image"], [], ["usage_id_document", "usage_id_image"],),
         # invalid/notfound attachments are kept because they may be non-xblock attachments
         # (eg. a labxchange native asset)
         (
             [],
             ["lx_document", "does_not_exist", "lx_image"],
             [],
-            ["lx_document", "does_not_exist", "lx_image"],
+            ["usage_id_document", "does_not_exist", "usage_id_image"],
         ),
         (
             [],
             ["lx_document", {"key": "invalid type"}, "lx_image"],
             [],
-            ["lx_document", "lx_image"],
+            ["usage_id_document", "usage_id_image"],
         ),
         (
             [],
             # duplicates are ok in attachments
             ["lx_document", "lx_document", "lx_image"],
             [],
-            ["lx_document", "lx_document", "lx_image"],
+            ["usage_id_document", "usage_id_document", "usage_id_image"],
         ),
     )
     @ddt.unpack
@@ -311,6 +311,6 @@ class CaseStudyBlockTestCase(XmlTest, BlockTestCaseBase):
                 ],
                 "display_name": "Case Study 4",
                 "sections": [],
-                "attachments": ["lx_image"],
+                "attachments": ["usage_id_image"],
             },
         )


### PR DESCRIPTION
Case Studies/Teaching Guides return original item usage_ids instead of replica `usage_ids`s for their child items (attachments and embedded).

[labxchange-xblocks#42 ](https://github.com/open-craft/labxchange-xblocks/pull/42) was only a partial fix -- it returned original item usage_ids for children of `sections`, but we forgot to fix the `attachment` items. This change fixes this.

**Jira tickets**

* [FAL-3217](https://tasks.opencraft.com/browse/FAL-3217)
* https://app.asana.com/0/1202820371412061/1203271065106044/f

**Testing instructions**

See https://gitlab.com/opencraft/client/LabXchange/labxchange-dev/-/merge_requests/TBD for manual testing instructions.

See [README#Testing on devstack](https://github.com/open-craft/labxchange-xblocks#testing-on-devstack) to check unit tests.